### PR TITLE
Docker bug fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt update \
     && add-apt-repository ppa:deadsnakes/ppa \
     && apt update \
     && apt install -y git libsndfile1-dev tesseract-ocr espeak-ng python3.9 python3.9-distutils python3-pip ffmpeg \
-    && python3.9 -m pip install --upgrade --no-cache-dir pip
+    && python3.9 -m pip install --upgrade --no-cache-dir pip requests
 
 # install pytorch
 ARG PYTORCH='1.13.1'

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,19 +37,6 @@ ENTRYPOINT [ "pytest" ]
 
 FROM base as dev
 
-# This creates a developer user with the same UID and GID as the host user
-ARG USER_ID
-ARG GROUP_ID
-
-RUN addgroup --gid $GROUP_ID developer
-RUN adduser --disabled-password --gecos '' --uid $USER_ID --gid $GROUP_ID developer
-
-ENV PATH="/home/developer/.local/bin:${PATH}"
-
-USER developer
-WORKDIR /home/developer/tuned-lens
-
-
 # Example usage:
 
 # Using the production image
@@ -62,6 +49,3 @@ WORKDIR /home/developer/tuned-lens
 
 # Using the development image
 # docker build -t tuned-lens-dev --target dev --build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g) .
-# docker run -it tuned-lens-dev --mount type=bind,source="$(pwd)",target=/home/developer/tuned-lens
-# Note: You will still need to install the package in the container in development mode
-# Warning: Don't push the development image to a public registry

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,12 @@ FROM nvidia/cuda:11.6.0-devel-ubuntu20.04 as base
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Most of this is a hack to get python 3.9 and pip installed on ubuntu 20.04
-RUN apt update
-RUN apt install -y software-properties-common
-RUN add-apt-repository ppa:deadsnakes/ppa
-
-RUN apt update
-RUN apt install -y git libsndfile1-dev tesseract-ocr espeak-ng python3.9 python3.9-distutils python3-pip ffmpeg
-RUN python3.9 -m pip install --upgrade --no-cache-dir pip
+RUN apt update \
+    && apt install -y software-properties-common \
+    && add-apt-repository ppa:deadsnakes/ppa \
+    && apt update \
+    && apt install -y git libsndfile1-dev tesseract-ocr espeak-ng python3.9 python3.9-distutils python3-pip ffmpeg \
+    && python3.9 -m pip install --upgrade --no-cache-dir pip
 
 # install pytorch
 ARG PYTORCH='1.13.1'
@@ -22,10 +21,10 @@ RUN [ ${#PYTORCH} -gt 0 ] && VERSION='torch=='$PYTORCH'.*' ||  VERSION='torch'; 
 # Install requirements for tuned lens repo note this only monitors 
 # the pytpoject.toml file for changes
 COPY pyproject.toml setup.cfg /workspace/
-RUN mkdir /workspace/tuned_lens
-RUN python3.9 -m pip install -e /workspace
-RUN python3.9 -m pip uninstall tuned-lens -y
-RUN rm -rf /workspace
+RUN mkdir /workspace/tuned_lens \
+    && python3.9 -m pip install -e /workspace \
+    && python3.9 -m pip uninstall tuned-lens -y \
+    && rm -rf /workspace
 
 FROM base as prod
 WORKDIR /workspace

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt update \
     && apt install -y software-properties-common \
     && add-apt-repository ppa:deadsnakes/ppa \
     && apt update \
-    && apt install -y git libsndfile1-dev tesseract-ocr espeak-ng python3.9 python3.9-distutils python3-pip ffmpeg \
+    && apt install -y git libsndfile1-dev tesseract-ocr espeak-ng python3.9 python3.9-distutils python3-pip ffmpeg zstd \
     && python3.9 -m pip install --upgrade --no-cache-dir pip requests
 
 # install pytorch

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "datasets",
     "plotly",
     "scikit-learn",
+    "zstandard",
     # Needed for Fully Sharded Data Parallel
     "torch>=1.12.0",
     "transformers",


### PR DESCRIPTION
## What this pull request addresses
GPU training on the current docker file does not work due to an incompatibility between the pytorch and cuda versions

## What I did
In order to use `torch=1.13.1` you need to use `cuda 11.6`the only docker file nvidia provides for this is based on `Ubuntu 20.04` which ships with `python3.8`. So to satisfy all the requirements for this I had to use a separate ppa to install `python3.9` and `pip`. Note that within the docker file you specifically need to run the code using the `python3.9` command and not the `pyhton3` or `python`. In addition, `pip` should always be used as a module so `python3.9 -m pip install <something>`.

Another solution to this problem is to upgrade to support pytorch 2.0 #14.