### PR TITLE
Switched atapters to translators everywhere in the code

### DIFF
--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -8,7 +8,7 @@ def test_plot_logit_lens():
     pythia_125M_model = AutoModelForCausalLM.from_pretrained("EleutherAI/pythia-125m")
     tokenizer = AutoTokenizer.from_pretrained("EleutherAI/pythia-125m")
     pythia_125M_lens = TunedLens(pythia_125M_model)
-    pythia_125M_lens.attn_adapters = th.nn.ModuleList()
+    pythia_125M_lens.attn_translators = th.nn.ModuleList()
     text = "Never gonna give you up, never gonna let you down,"
     text += " never gonna run around and desert you"
     input_ids = tokenizer(text, return_tensors="pt").input_ids

--- a/tuned_lens/causal/subspaces.py
+++ b/tuned_lens/causal/subspaces.py
@@ -58,7 +58,7 @@ def extract_causal_bases(
     labels: Optional[th.Tensor] = None,
     max_iter: int = 100,
     mode: Literal["mean", "resample", "zero"] = "mean",
-    no_adapter: bool = False,
+    no_translator: bool = False,
 ) -> Iterable[CausalBasis]:
     """Extract causal bases for probes at each layer of a model.
 
@@ -96,7 +96,9 @@ def extract_causal_bases(
 
         elif isinstance(model, TunedLens):
             logits = (
-                model(hiddens[i], i) if not no_adapter else model.to_logits(hiddens[i])
+                model(hiddens[i], i)
+                if not no_translator
+                else model.to_logits(hiddens[i])
             )
             log_p = logits.log_softmax(-1)
             U = (eye + model[i].weight.data.T) @ U

--- a/tuned_lens/nn/lenses.py
+++ b/tuned_lens/nn/lenses.py
@@ -22,6 +22,7 @@ class Lens(abc.ABC, th.nn.Module):
 
 class LogitLens(Lens):
     """Decodes the residual stream into logits using the unembeding matrix."""
+
     layer_norm: th.nn.LayerNorm
     unembedding: th.nn.Linear
     extra_layers: th.nn.Sequential
@@ -83,7 +84,7 @@ class TunedLens(Lens):
     layer_norm: th.nn.LayerNorm
     unembedding: th.nn.Linear
     extra_layers: th.nn.Sequential
-    layer_adapters: th.nn.ModuleList
+    layer_translators: th.nn.ModuleList
 
     def __init__(
         self,
@@ -122,7 +123,11 @@ class TunedLens(Lens):
 
         self.extra_layers = th.nn.Sequential()
 
-        if model is None == (d_model is None or num_layers is None or vocab_size is None):
+        if (
+            model
+            is None
+            == (d_model is None or num_layers is None or vocab_size is None)
+        ):
             raise ValueError(
                 "Must provide either a model or d_model, num_layers, and vocab_size"
             )
@@ -167,42 +172,40 @@ class TunedLens(Lens):
         self.unembedding.requires_grad_(False)
 
         out_features = d_model if reuse_unembedding else vocab_size
-        adapter = th.nn.Linear(d_model, out_features, bias=bias)
+        translator = th.nn.Linear(d_model, out_features, bias=bias)
         if not reuse_unembedding:
-            adapter.weight.data = self.unembedding.weight.data.clone()
-            adapter.bias.data.zero_()
+            translator.weight.data = self.unembedding.weight.data.clone()
+            translator.bias.data.zero_()
         else:
-            adapter.weight.data.zero_()
-            adapter.bias.data.zero_()
+            translator.weight.data.zero_()
+            translator.bias.data.zero_()
 
-        self.add_module("input_adapter", adapter if include_input else None)
+        self.add_module("input_translator", translator if include_input else None)
         # Don't include the final layer
         num_layers -= 1
 
-        self.layer_adapters = th.nn.ModuleList(
-            [deepcopy(adapter) for _ in range(num_layers)]
+        self.layer_translators = th.nn.ModuleList(
+            [deepcopy(translator) for _ in range(num_layers)]
         )
 
     def __getitem__(self, item: int) -> th.nn.Module:
         """Get the probe module at the given index."""
-        if isinstance(self.input_adapter, th.nn.Module):
+        if isinstance(self.input_translator, th.nn.Module):
             if item == 0:
-                return self.input_adapter
+                return self.input_translator
             else:
                 item -= 1
 
-        return self.layer_adapters[item]
+        return self.layer_translators[item]
 
     def __iter__(self) -> Generator[th.nn.Module, None, None]:
-        if isinstance(self.input_adapter, th.nn.Module):
-            yield self.input_adapter
+        if isinstance(self.input_translator, th.nn.Module):
+            yield self.input_translator
 
-        yield from self.layer_adapters
+        yield from self.layer_translators
 
     @classmethod
-    def load(
-        cls, resource_id: str, **kwargs
-    ) -> "TunedLens":
+    def load(cls, resource_id: str, **kwargs) -> "TunedLens":
         """Load a tuned lens from a or hugging face hub.
 
         Args:
@@ -225,7 +228,7 @@ class TunedLens(Lens):
         keys = list(state.keys())
         for key in keys:
             if "probe" in key:
-                new_key = key.replace("probe", "adapter")
+                new_key = key.replace("probe", "translator")
                 state[new_key] = state.pop(key)
 
         # Drop unrecognized config keys
@@ -284,7 +287,7 @@ class TunedLens(Lens):
         if not self.config["reuse_unembedding"]:
             raise RuntimeError("TunedLens.transform_hidden requires reuse_unembedding")
 
-        # Note that we add the adapter output residually, in contrast to the formula
+        # Note that we add the translator output residually, in contrast to the formula
         # in the paper. By parametrizing it this way we ensure that weight decay
         # regularizes the transform toward the identity, not the zero transformation.
         return h + self[idx](h)
@@ -312,8 +315,8 @@ class TunedLens(Lens):
         return self.to_logits(h)
 
     def __len__(self) -> int:
-        N = len(self.layer_adapters)
-        if self.input_adapter:
+        N = len(self.layer_translators)
+        if self.input_translator:
             N += 1
 
         return N

--- a/tuned_lens/nn/lenses.py
+++ b/tuned_lens/nn/lenses.py
@@ -224,12 +224,13 @@ class TunedLens(Lens):
         # Load parameters
         state = th.load(ckpt_path, **kwargs)
 
-        # Backwards compatibility
+        # Backwards compatibility we really need to stop renaming things
         keys = list(state.keys())
         for key in keys:
-            if "probe" in key:
-                new_key = key.replace("probe", "translator")
-                state[new_key] = state.pop(key)
+            for old_key in ["probe", "adapter"]:
+                if old_key in key:
+                    new_key = key.replace(old_key, "translator")
+                    state[new_key] = state.pop(key)
 
         # Drop unrecognized config keys
         unrecognized = set(config) - set(inspect.getfullargspec(cls).kwonlyargs)

--- a/tuned_lens/nn/lenses.py
+++ b/tuned_lens/nn/lenses.py
@@ -1,5 +1,6 @@
 from copy import deepcopy
 import inspect
+from logging import warn
 from pathlib import Path
 import json
 import abc
@@ -229,6 +230,10 @@ class TunedLens(Lens):
         for key in keys:
             for old_key in ["probe", "adapter"]:
                 if old_key in key:
+                    warn(
+                        f"Loading a checkpoint with a '{old_key}' key. "
+                        "This is deprecated and will be removed in the future."
+                    )
                     new_key = key.replace(old_key, "translator")
                     state[new_key] = state.pop(key)
 

--- a/tuned_lens/nn/lenses.py
+++ b/tuned_lens/nn/lenses.py
@@ -232,7 +232,7 @@ class TunedLens(Lens):
                 if old_key in key:
                     warn(
                         f"Loading a checkpoint with a '{old_key}' key. "
-                        "This is deprecated and will be removed in the future."
+                        "This is deprecated and may be removed in a future version. "
                     )
                     new_key = key.replace(old_key, "translator")
                     state[new_key] = state.pop(key)

--- a/tuned_lens/scripts/argparsers.py
+++ b/tuned_lens/scripts/argparsers.py
@@ -40,7 +40,7 @@ def get_cbe_parser() -> ArgumentParser:
         "lens", type=Path, help="Directory containing the tuned lens to use.", nargs="?"
     )
     extract_parser.add_argument(
-        "--no-adapter", action="store_true", help="Do not use learned probes."
+        "--no-translator", action="store_true", help="Do not use learned probes."
     )
     extract_parser.add_argument(
         "--k", type=int, default=50, help="Number of basis vectors to extract."

--- a/tuned_lens/scripts/cbe.py
+++ b/tuned_lens/scripts/cbe.py
@@ -100,7 +100,7 @@ def extract_bases(
         k=args.k,
         labels=batch["input_ids"] if args.loss == "ce" else None,
         mode=args.mode,
-        no_adapter=args.no_adapter,
+        no_translator=args.no_translator,
     )
     for i, basis in enumerate(basis_iter):
         if local_rank == 0:


### PR DESCRIPTION
I've renamed all of the adapters to translators and added a backwards comparability check so that model can still be loaded with the old keys. I've also added a warning saying that those keys are deprecated.