### PR TITLE
CPU offload option

### DIFF
--- a/tuned_lens/__main__.py
+++ b/tuned_lens/__main__.py
@@ -27,6 +27,11 @@ def run():
         "suitable to be passed to the HuggingFace load_dataset function.",
     )
     parent_parser.add_argument(
+        "--cpu-offload",
+        action="store_true",
+        help="Use CPU offloading. Must be combined with --fsdp.",
+    )
+    parent_parser.add_argument(
         "--fsdp",
         action="store_true",
         help="Run the model with Fully Sharded Data Parallelism.",

--- a/tuned_lens/scripts/lens.py
+++ b/tuned_lens/scripts/lens.py
@@ -118,7 +118,9 @@ def main(args):
 
     # Load tokenizer & data
     tokenizer = AutoTokenizer.from_pretrained(
-        args.tokenizer or args.model_name, use_fast=not args.slow_tokenizer
+        args.tokenizer or args.model_name,
+        use_fast=not args.slow_tokenizer,
+        revision=args.revision,
     )
     assert isinstance(tokenizer, PreTrainedTokenizerBase)
     silence_datasets_messages()

--- a/tuned_lens/scripts/lens.py
+++ b/tuned_lens/scripts/lens.py
@@ -103,7 +103,7 @@ def main(args):
             auto_wrap_policy=partial(
                 transformer_auto_wrap_policy, transformer_layer_cls={layer_cls}
             ),
-            cpu_offload=CPUOffload(offload_params=True),
+            cpu_offload=CPUOffload(offload_params=args.cpu_offload),
             device_id=local_rank,
             # This turns out to be important for training speed
             forward_prefetch=True,
@@ -113,6 +113,8 @@ def main(args):
                 buffer_dtype=th.float16,
             ),
         )
+    elif args.cpu_offload:
+        raise ValueError("CPU offload requires FSDP.")
     else:
         model.to(local_rank)
 


### PR DESCRIPTION
Before, when you passed in `--fsdp` it would automatically also do CPU offload, but this makes it so you have to pass in `--cpu-offload` to get that behavior. When training a probe for LLaMA 13B I noticed CPU offload was sort of unnecessary and was probably slowing things down but FSDP was needed.