### PR TITLE
Upgrade to pytorch 2.0

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -19,3 +19,5 @@ coverage.xml
 .github
 .vscode
 .ruff_cache
+__pycache__/
+.ipynb_checkpoints

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   pre-commit:
-    name: "Pre-commit checks"
+    name: Pre-commit checks
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -16,7 +16,7 @@ jobs:
       with:
         extra_args: ruff --all-files
   test-docs:
-    name: "Run build docs and tune doctests"
+    name: Run build docs and tune doctests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -34,8 +34,29 @@ jobs:
       - name: Run doc-tests
         run: |
           cd docs && make doctest
-  build-and-test:
-    name: "Build Docker image and run unit tests within it"
+  python-build-and-test:
+    name: Install and run tests to ensure dependencies are specific enough.
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11"]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout
+      - name: Setup python
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{matrix.python-version}}
+          cache: 'pip'
+          cache-dependency-path: pyproject.toml
+      - name: Install dependencies
+        run: |
+          pip install -e .[test]
+      - name: Run basic unit tests
+        run: |
+          pytest
+  docker-build-and-test:
+    name: Build Docker image and run unit tests within it. Keeping track of coverage
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -42,7 +42,7 @@ jobs:
         python-version: ["3.9", "3.10", "3.11"]
     steps:
       - name: Checkout code
-        uses: actions/checkout
+        uses: actions/checkout@v2
       - name: Setup python
         uses: actions/setup-python@v3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ Data/
 notebooks/memorization.ipynb
 .ruff_cache
 lens/
+.cvsignore
 
 
 # Byte-compiled / optimized / DLL files

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt update \
 ARG PYTORCH='1.13.1'
 ARG CUDA='cu118'
 
-RUN [ ${#PYTORCH} -gt 0 ] && VERSION='torch=='$PYTORCH'.*' ||  VERSION='torch'; python3 -m pip install --no-cache-dir -U $VERSION --extra-index-url https://download.pytorch.org/whl/$CUDA
+RUN [ ${#PYTORCH} -gt 0 ] && VERSION='torch=='$PYTORCH'.*' ||  VERSION='torch'; python3 -m pip install --no-cache-dir -U $VERSION --extra-index-url https://download.pytorch.org/whl/nightly/$CUDA
 
 # Install requirements for tuned lens repo note this only monitors
 # the pytpoject.toml file for changes

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,6 @@
 # syntax = docker/dockerfile:1
 
-FROM nvidia/cuda:11.8.0-devel-ubuntu22.04 as base
-
-ARG DEBIAN_FRONTEND=noninteractive
-
-# Most of this is a hack to get python 3.9 and pip installed on ubuntu 20.04
-RUN apt update \
-    && apt install -y git libsndfile1-dev tesseract-ocr espeak-ng python3 python3-pip ffmpeg zstd \
-    && python3 -m pip install --upgrade --no-cache-dir pip requests
-
-# install pytorch
-ARG PYTORCH='1.13.1'
-ARG CUDA='cu118'
-
-RUN [ ${#PYTORCH} -gt 0 ] && VERSION='torch=='$PYTORCH'.*' ||  VERSION='torch'; python3 -m pip install --no-cache-dir -U $VERSION --extra-index-url https://download.pytorch.org/whl/nightly/$CUDA
-
-# Install requirements for tuned lens repo note this only monitors
-# the pytpoject.toml file for changes
+FROM pytorch/pytorch:2.0.0-cuda11.7-cudnn8-runtime as base
 
 FROM base as prod
 ADD . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,21 @@
 # syntax = docker/dockerfile:1
 
-FROM pytorch/pytorch:2.0.0-cuda11.7-cudnn8-runtime as base
+FROM nvidia/cuda:11.8.0-devel-ubuntu22.04 as base
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt update \
+    && apt install -y git tini libsndfile1-dev tesseract-ocr espeak-ng python3 python3-pip ffmpeg zstd \
+    && python3 -m pip install --upgrade --no-cache-dir pip requests
+
+# install pytorch
+ARG PYTORCH='2.0'
+ARG CUDA='cu118'
+
+RUN [ ${#PYTORCH} -gt 0 ] && VERSION='torch=='$PYTORCH'.*' ||  VERSION='torch'; python3 -m pip install --no-cache-dir -U $VERSION --extra-index-url https://download.pytorch.org/whl/nightly/$CUDA
+
+# Install requirements for tuned lens repo note this only monitors
+# the pytpoject.toml file for changes
 
 FROM base as prod
 ADD . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax = docker/dockerfile:1
 
-FROM nvidia/cuda:11.6.0-devel-ubuntu20.04 as base
+FROM nvidia/cuda:11.8.0-devel-ubuntu22.04 as base
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -14,7 +14,7 @@ RUN apt update \
 
 # install pytorch
 ARG PYTORCH='1.13.1'
-ARG CUDA='cu116'
+ARG CUDA='cu118'
 
 RUN [ ${#PYTORCH} -gt 0 ] && VERSION='torch=='$PYTORCH'.*' ||  VERSION='torch'; python3.9 -m pip install --no-cache-dir -U $VERSION --extra-index-url https://download.pytorch.org/whl/$CUDA
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,40 +6,37 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 # Most of this is a hack to get python 3.9 and pip installed on ubuntu 20.04
 RUN apt update \
-    && apt install -y software-properties-common \
-    && add-apt-repository ppa:deadsnakes/ppa \
-    && apt update \
-    && apt install -y git libsndfile1-dev tesseract-ocr espeak-ng python3.9 python3.9-distutils python3-pip ffmpeg zstd \
-    && python3.9 -m pip install --upgrade --no-cache-dir pip requests
+    && apt install -y git libsndfile1-dev tesseract-ocr espeak-ng python3 python3-pip ffmpeg zstd \
+    && python3 -m pip install --upgrade --no-cache-dir pip requests
 
 # install pytorch
 ARG PYTORCH='1.13.1'
 ARG CUDA='cu118'
 
-RUN [ ${#PYTORCH} -gt 0 ] && VERSION='torch=='$PYTORCH'.*' ||  VERSION='torch'; python3.9 -m pip install --no-cache-dir -U $VERSION --extra-index-url https://download.pytorch.org/whl/$CUDA
+RUN [ ${#PYTORCH} -gt 0 ] && VERSION='torch=='$PYTORCH'.*' ||  VERSION='torch'; python3 -m pip install --no-cache-dir -U $VERSION --extra-index-url https://download.pytorch.org/whl/$CUDA
 
 # Install requirements for tuned lens repo note this only monitors
 # the pytpoject.toml file for changes
 
 FROM base as prod
 ADD . .
-RUN python3.9 -m pip install .
+RUN python3 -m pip install .
 
 FROM base as test
 COPY pyproject.toml setup.cfg /workspace/
 WORKDIR /workspace
 # Have all the dependencies installed so that we can cache them
 RUN mkdir tuned_lens \
-    && python3.9 -m pip install -e ".[test]" \
-    && python3.9 -m pip uninstall -y tuned_lens \
+    && python3 -m pip install -e ".[test]" \
+    && python3 -m pip uninstall -y tuned_lens \
     && rmdir tuned_lens && rm pyproject.toml setup.cfg
 
 FROM base as dev
 COPY pyproject.toml setup.cfg /workspace/
 WORKDIR /workspace
 RUN mkdir tuned_lens \
-    && python3.9 -m pip install -e ".[dev]" \
-    && python3.9 -m pip uninstall tuned_lens \
+    && python3 -m pip install -e ".[dev]" \
+    && python3 -m pip uninstall -y tuned_lens \
     && rmdir tuned_lens && rm pyproject.toml setup.cfg
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,7 @@ dependencies = [
     "plotly>=5.13.1",
     "scikit-learn",
     "zstandard",
-    # Needed for Fully Sharded Data Parallel
-    "torch>=1.12.0",
+    "torch>=2.0.0",
     "transformers",
     "huggingface_hub>=0.12.1",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "plotly>=5.13.1",
     "scikit-learn",
     "zstandard",
-    "torch>=2.0.0",
+    "torch>=1.13.0",
     "transformers",
     "huggingface_hub>=0.12.1",
 ]

--- a/tuned_lens/causal/subspaces.py
+++ b/tuned_lens/causal/subspaces.py
@@ -166,7 +166,7 @@ def extract_causal_bases(
                 nonlocal energy_delta, nfev, last_energy
                 nfev += 1
 
-                opt.zero_grad()
+                opt.zero_grad(set_to_none=False)
                 v_ = project(v)
                 h_ = remove_subspace(hiddens[i], v_, mode=mode, orthonormal=True)
 
@@ -200,7 +200,7 @@ def extract_causal_bases(
                 if not loss.isfinite():
                     print("Loss is not finite")
                     loss = th.tensor(0.0, device=device)
-                    opt.zero_grad()
+                    opt.zero_grad(set_to_none=False)
 
                 return loss
 

--- a/tuned_lens/nn/decoder.py
+++ b/tuned_lens/nn/decoder.py
@@ -262,7 +262,7 @@ class Decoder(th.nn.Module):
             nonlocal nfev, loss, kl
             nfev += 1
 
-            opt.zero_grad()
+            opt.zero_grad(set_to_none=False)
             loss, kl = compute_loss(h_star)
 
             if not loss.isfinite():

--- a/tuned_lens/scripts/train_loop.py
+++ b/tuned_lens/scripts/train_loop.py
@@ -215,7 +215,7 @@ def train_loop(
         if rem == 0:
             th.nn.utils.clip_grad_norm_(lens.parameters(), 1.0)
             opt.step()
-            opt.zero_grad()
+            opt.zero_grad(set_to_none=False)
             scheduler.step()
 
             if local_rank == 0 and args.wandb:

--- a/tuned_lens/stats/logit_stats.py
+++ b/tuned_lens/stats/logit_stats.py
@@ -65,7 +65,7 @@ class LogitStats:
         )
 
         def closure():
-            opt.zero_grad()
+            opt.zero_grad(set_to_none=False)
 
             # See http://jonathan-huang.org/research/dirichlet/dirichlet.pdf,
             # page 5 for the formula


### PR DESCRIPTION
This greatly simplifies both our CI and gets around some very annoying bugs in torch 1.13.1. In addition, torch 2.0 does not appear to have very many breaking changes, so this should be a smooth transition https://github.com/pytorch/pytorch/releases.