### PR TITLE
Refactor CLI args Part 2 - Add type hinting to CLI args

### DIFF
--- a/tuned_lens/__main__.py
+++ b/tuned_lens/__main__.py
@@ -12,7 +12,7 @@ from .scripts.eval_loop import cli_args as eval_cli_args
 
 
 class SharedCliArgs:
-    """Type hinting for CLI args used for both training and evaluation"""
+    """Type hinting for CLI args used for both training and evaluation."""
     model_name: str
     dataset: Optional[List[str]]
     cpu_offload: bool

--- a/tuned_lens/__main__.py
+++ b/tuned_lens/__main__.py
@@ -12,6 +12,7 @@ from .scripts.eval_loop import cli_args as eval_cli_args
 
 
 class SharedCliArgs:
+    """Type hinting for CLI args used for both training and evaluation"""
     model_name: str
     dataset: Optional[List[str]]
     cpu_offload: bool

--- a/tuned_lens/__main__.py
+++ b/tuned_lens/__main__.py
@@ -1,6 +1,6 @@
 """Script to train or evaluate a set of tuned lenses for a language model."""
 
-from typing import List, TypedDict
+from typing import List, Optional, TypedDict, get_type_hints
 from .scripts.lens import main as lens_main
 from argparse import ArgumentParser
 from contextlib import nullcontext, redirect_stdout
@@ -12,24 +12,48 @@ from .scripts.downstream import cli_args as downstream_cli_args
 from .scripts.eval_loop import cli_args as eval_cli_args
 
 
+class SharedCliArgs:
+    model_name: str
+    dataset: Optional[List[str]]
+    cpu_offload: bool
+    fsdp: bool
+    loss: str
+    no_cache: bool
+    per_gpu_batch_size: int
+    random_model: bool
+    residual_stats: bool
+    revision: str
+    seed: int
+    slow_tokenizer: bool
+    split: str
+    sweep: str
+    task: List[str]
+    text_column: str
+    tokenizer: str
+    tokenizer_type: str
+    token_shift: int
+
+
 class Arg(TypedDict):
     name_or_flags: List[str]
     options: dict
 
+
+arg_types = get_type_hints(SharedCliArgs)
 
 # Arguments shared by train and eval; see https://stackoverflow.com/a/56595689.
 shared_cli_args: List[Arg] = [
     {
         "name_or_flags": ["model_name"],
         "options": {
-            "type": str,
+            "type": arg_types["model_name"],
             "help": "Name of model to use in the Huggingface Hub.",
         },
     },
     {
         "name_or_flags": ["dataset"],
         "options": {
-            "type": str,
+            "type": arg_types["dataset"],
             "default": ("the_pile", "all"),
             "nargs": "*",
             "help": "Name of dataset to use. Can either be a local .jsonl file or a name suitable to be passed to the HuggingFace load_dataset function.",
@@ -38,6 +62,7 @@ shared_cli_args: List[Arg] = [
     {
         "name_or_flags": ["--cpu-offload"],
         "options": {
+            "type": arg_types["cpu_offload"],
             "action": "store_true",
             "help": "Use CPU offloading. Must be combined with --fsdp.",
         },
@@ -45,6 +70,7 @@ shared_cli_args: List[Arg] = [
     {
         "name_or_flags": ["--fsdp"],
         "options": {
+            "type": arg_types["fsdp"],
             "action": "store_true",
             "help": "Run the model with Fully Sharded Data Parallelism.",
         },
@@ -52,7 +78,7 @@ shared_cli_args: List[Arg] = [
     {
         "name_or_flags": ["--loss"],
         "options": {
-            "type": str,
+            "type": arg_types["loss"],
             "default": "kl",
             "choices": ("ce", "kl"),
             "help": "Loss function to use.",
@@ -61,6 +87,7 @@ shared_cli_args: List[Arg] = [
     {
         "name_or_flags": ["--no-cache"],
         "options": {
+            "type": arg_types["no_cache"],
             "action": "store_true",
             "help": "Don't permanently cache the model on disk.",
         },
@@ -68,7 +95,7 @@ shared_cli_args: List[Arg] = [
     {
         "name_or_flags": ["--per-gpu-batch-size"],
         "options": {
-            "type": int,
+            "type": arg_types["per_gpu_batch_size"],
             "default": 1,
             "help": "Number of samples to try to fit on a GPU at once.",
         },
@@ -76,6 +103,7 @@ shared_cli_args: List[Arg] = [
     {
         "name_or_flags": ["--random-model"],
         "options": {
+            "type": arg_types["random_model"],
             "action": "store_true",
             "help": "Use a randomly initialized model instead of pretrained weights.",
         },
@@ -83,6 +111,7 @@ shared_cli_args: List[Arg] = [
     {
         "name_or_flags": ["--residual-stats"],
         "options": {
+            "type": arg_types["residual_stats"],
             "action": "store_true",
             "help": "Save means and covariance matrices for states in the residual stream.",
         },
@@ -90,7 +119,7 @@ shared_cli_args: List[Arg] = [
     {
         "name_or_flags": ["--revision"],
         "options": {
-            "type": str,
+            "type": arg_types["revision"],
             "default": "main",
             "help": "Git revision to use for pretrained models.",
         },
@@ -98,31 +127,38 @@ shared_cli_args: List[Arg] = [
     {
         "name_or_flags": ["--seed"],
         "options": {
-            "type": int,
+            "type": arg_types["seed"],
             "default": 42,
             "help": "Random seed for data shuffling.",
         },
     },
     {
         "name_or_flags": ["--slow-tokenizer"],
-        "options": {"action": "store_true", "help": "Use a slow tokenizer."},
+        "options": {
+            "type": arg_types["slow_tokenizer"],
+            "action": "store_true",
+            "help": "Use a slow tokenizer.",
+        },
     },
     {
         "name_or_flags": ["--split"],
         "options": {
-            "type": str,
+            "type": arg_types["split"],
             "default": "validation",
             "help": "Split of the dataset to use.",
         },
     },
     {
         "name_or_flags": ["--sweep"],
-        "options": {"type": str, "help": "Range of checkpoints to sweep over"},
+        "options": {
+            "type": arg_types["sweep"],
+            "help": "Range of checkpoints to sweep over",
+        },
     },
     {
         "name_or_flags": ["--task"],
         "options": {
-            "type": str,
+            "type": arg_types["task"],
             "nargs": "+",
             "help": "lm-eval task to run the model on.",
         },
@@ -130,7 +166,7 @@ shared_cli_args: List[Arg] = [
     {
         "name_or_flags": ["--text-column"],
         "options": {
-            "type": str,
+            "type": arg_types["text_column"],
             "default": "text",
             "help": "Column of the dataset containing text to run the model on.",
         },
@@ -138,21 +174,21 @@ shared_cli_args: List[Arg] = [
     {
         "name_or_flags": ["--tokenizer"],
         "options": {
-            "type": str,
+            "type": arg_types["tokenizer"],
             "help": "Name of pretrained tokenizer to use from the Huggingface Hub. If None, will use AutoTokenizer.from_pretrained('<model name>').",
         },
     },
     {
         "name_or_flags": ["--tokenizer-type"],
         "options": {
-            "type": str,
+            "type": arg_types["tokenizer_type"],
             "help": "Name of tokenizer class to use. If None, will use AutoTokenizer.",
         },
     },
     {
         "name_or_flags": ["--token-shift"],
         "options": {
-            "type": int,
+            "type": arg_types["token_shift"],
             "default": None,
             "help": "How to shift the labels wrt the input tokens (1 = next token, 0 = current token, -1 = previous token, etc.)",
         },

--- a/tuned_lens/scripts/downstream.py
+++ b/tuned_lens/scripts/downstream.py
@@ -23,7 +23,7 @@ print "{}":\n\n"""
 
 
 class CliArgs(SharedCliArgs):
-    """Type hinting for CLI args"""
+    """Type hinting for CLI args."""
     lens: Path
     injection: bool
     incorrect_fewshot: bool

--- a/tuned_lens/scripts/downstream.py
+++ b/tuned_lens/scripts/downstream.py
@@ -1,5 +1,4 @@
 """Provides Sub command for downstream evaluation."""
-from argparse import Namespace
 from collections import defaultdict
 from pathlib import Path
 from datasets import Dataset
@@ -24,6 +23,7 @@ print "{}":\n\n"""
 
 
 class CliArgs(SharedCliArgs):
+    """Type hinting for CLI args"""
     lens: Path
     injection: bool
     incorrect_fewshot: bool

--- a/tuned_lens/scripts/eval_loop.py
+++ b/tuned_lens/scripts/eval_loop.py
@@ -25,7 +25,7 @@ import torch.distributed as dist
 
 
 class CliArgs(SharedCliArgs):
-    """Type hinting for CLI args"""
+    """Type hinting for CLI args."""
     lens: Path
     grad_alignment: bool
     limit: int

--- a/tuned_lens/scripts/eval_loop.py
+++ b/tuned_lens/scripts/eval_loop.py
@@ -1,5 +1,4 @@
 """Evaluation loop for the tuned lens model."""
-from argparse import Namespace
 from pathlib import Path
 from datasets import Dataset
 from collections import defaultdict
@@ -26,6 +25,7 @@ import torch.distributed as dist
 
 
 class CliArgs(SharedCliArgs):
+    """Type hinting for CLI args"""
     lens: Path
     grad_alignment: bool
     limit: int

--- a/tuned_lens/scripts/train_loop.py
+++ b/tuned_lens/scripts/train_loop.py
@@ -1,5 +1,4 @@
 """Training loop for training a TunedLens model against a transformer on a dataset."""
-from argparse import Namespace
 from collections import defaultdict
 from typing import List, Optional, get_type_hints
 from pathlib import Path
@@ -24,6 +23,7 @@ import torch.distributed as dist
 
 
 class CliArgs(SharedCliArgs):
+    """Type hinting for CLI args"""
     constant: bool
     extra_layers: int
     lasso: float

--- a/tuned_lens/scripts/train_loop.py
+++ b/tuned_lens/scripts/train_loop.py
@@ -23,7 +23,7 @@ import torch.distributed as dist
 
 
 class CliArgs(SharedCliArgs):
-    """Type hinting for CLI args"""
+    """Type hinting for CLI args."""
     constant: bool
     extra_layers: int
     lasso: float


### PR DESCRIPTION
This builds on #64  to add typing to the CLI args. Let me know if this is taking the refactor too far but I thought it would be satisfying and cool to reuse the typing already specified in the CLI arg configuration for actual type hinting. This way we can be sure that CLI args are actually supported in the code and any args used in the code are included in the CLI args.

I tried to figure out a way to infer the types directly from the argparser without having to re-specify but couldn't figure out a way to do that. The `Namespace` object provided by argparse just type hints everything as `Any` and doesn't specify which attributes exist and which don't. There might be better type hinting practices for other argparsers like click but I didn't want to go too far with the refactor since there's already a good bit of change. That's something to potentially improve in the future.