### PR TITLE
Support tuned lens training in 8 bit with `bitsandbytes`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,9 @@ test = [
 notebooks = [
     "ipywidgets",
 ]
+8bit = [
+    "bitsandbytes",
+]
 
 [project.scripts]
 tuned-lens = "tuned_lens.__main__:main"

--- a/tuned_lens/scripts/eval_loop.py
+++ b/tuned_lens/scripts/eval_loop.py
@@ -75,11 +75,11 @@ class Eval:
     def execute(self):
         """Trains a TunedLens model against a transformer on a dataset."""
         # Load model, tokenizer, data, and lens
-        self.dist.init()
+        device_map = self.dist.init()
         model = tokenizer = data = lens = nats_to_bpb = model_name = None
         if self.dist.primary:
             # Let the primary processes populate the cache
-            model, tokenizer = self.model.load()
+            model, tokenizer = self.model.load(device_map)
             data, nats_to_bpb = self.data.load(tokenizer)
             lens = self.load_lens(model)
 
@@ -87,7 +87,7 @@ class Eval:
 
         if not self.dist.primary:
             # Let the non-primary processes load from the cache
-            model, tokenizer = self.model.load(must_use_cache=True)
+            model, tokenizer = self.model.load(device_map, must_use_cache=True)
             data, nats_to_bpb = self.data.load(tokenizer)
             lens = self.load_lens(model)
 

--- a/tuned_lens/scripts/ingredients.py
+++ b/tuned_lens/scripts/ingredients.py
@@ -88,6 +88,9 @@ class Model:
     name: str
     """Name of model to use in the Huggingface Hub."""
 
+    int8: bool = field(action="store_true", default=False)
+    """Load the model weights in mixed int8 mode with `bitsandbytes`."""
+
     revision: str = "main"
     """Git revision to use for pretrained models."""
 
@@ -121,6 +124,8 @@ class Model:
         print(f"Loading pretrained weights for '{self.name}'...")
         model = AutoModelForCausalLM.from_pretrained(  # type: ignore
             self.name,
+            device_map={"": "cpu"}, # No-op required for load_in_8bit
+            load_in_8bit=self.int8,
             low_cpu_mem_usage=True,
             revision=self.revision,
             torch_dtype="auto",

--- a/tuned_lens/scripts/ingredients.py
+++ b/tuned_lens/scripts/ingredients.py
@@ -316,7 +316,7 @@ class Distributed:
 
     def init(self) -> dict[str, th.device]:
         """Initialize distributed process group if started with elastic launch.
-        
+
         Returns:
             Dictionary which can be passed to `device_map` in HF's `from_pretrained`
             methods.
@@ -329,9 +329,9 @@ class Distributed:
                 th.cuda.is_available()
             ), "CUDA must be available for distributed training"
             th.cuda.set_device(self.local_rank)
-        
+
             return {"": th.device("cuda", self.local_rank)}
-        
+
         return {"": self.device}
 
     def barrier(self) -> None:

--- a/tuned_lens/scripts/train_loop.py
+++ b/tuned_lens/scripts/train_loop.py
@@ -20,7 +20,7 @@ from tuned_lens.scripts.ingredients import (
     Model,
     Optimizer,
 )
-from tuned_lens.utils import maybe_all_reduce, shift_labels, shift_preds, pytree_map
+from tuned_lens.utils import maybe_all_reduce, shift_labels, shift_preds
 
 
 class LossChoice(enum.Enum):


### PR DESCRIPTION
This adds an `int8` field to the `Model` config class which sets `load_in_8bit=True` when `AutoModelForCausalLM.from_pretrained` is called.

I had to do a little bit of refactoring in order for this to work because `load_in_8bit=True` requires a `device_map` to be set, and in `main` the `Model` class doesn't actually know what device it's supposed to be on. Also, FSDP is simply incompatible with the `device_map` flag, so I have to turn that off when `fsdp` is enabled.