### PR TITLE
Added use_auth_token to access gated HF models

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "simple-parsing>=0.1.1",
     "flatten-dict>=0.4.1",
     "wandb>=0.15.0",
+    "python-dotenv",
 ]
 version = "0.2.0"
 

--- a/tuned_lens/scripts/ingredients.py
+++ b/tuned_lens/scripts/ingredients.py
@@ -110,6 +110,9 @@ class Model:
 
     tokenizer_type: Optional[str] = None
     """Name of tokenizer class to use. If None, will use AutoTokenizer."""
+    
+    use_auth_token: Optional[str] = field(default=None, alias="--use_auth_token")
+    """Auth token to use when loading gated models from the Huggingface Hub."""
 
     def load_tokenizer(self, must_use_cache: bool = False) -> PreTrainedTokenizerBase:
         """Load the tokenizer from huggingface hub."""
@@ -147,6 +150,8 @@ class Model:
             }[self.precision]
         except KeyError as e:
             raise ValueError(f"Unknown precision: {self.precision}") from e
+        
+        use_auth_token_kwargs = {"use_auth_token": self.use_auth_token} if self.use_auth_token else {}
 
         with handle_name_conflicts():
             model = AutoModelForCausalLM.from_pretrained(  # type: ignore
@@ -157,6 +162,7 @@ class Model:
                 revision=self.revision,
                 torch_dtype=dtype,
                 local_files_only=must_use_cache,
+                **use_auth_token_kwargs,
             )
 
         assert isinstance(model, PreTrainedModel)

--- a/tuned_lens/scripts/ingredients.py
+++ b/tuned_lens/scripts/ingredients.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from datetime import timedelta
 from functools import partial
 from typing import Optional, Union
+from dotenv import load_dotenv 
 
 import torch as th
 import torch.distributed as dist
@@ -39,6 +40,7 @@ from tuned_lens.utils import (
     send_to_device,
 )
 
+load_dotenv()
 
 @dataclass
 class Data:
@@ -111,7 +113,7 @@ class Model:
     tokenizer_type: Optional[str] = None
     """Name of tokenizer class to use. If None, will use AutoTokenizer."""
     
-    use_auth_token: Optional[str] = field(default=None, alias="--use_auth_token")
+    use_auth_token: Optional[str] = os.environ.get('HF_TOKEN') if os.environ.get('HF_TOKEN') else None
     """Auth token to use when loading gated models from the Huggingface Hub."""
 
     def load_tokenizer(self, must_use_cache: bool = False) -> PreTrainedTokenizerBase:

--- a/tuned_lens/scripts/ingredients.py
+++ b/tuned_lens/scripts/ingredients.py
@@ -116,6 +116,9 @@ class Model:
 
     def load_tokenizer(self, must_use_cache: bool = False) -> PreTrainedTokenizerBase:
         """Load the tokenizer from huggingface hub."""
+        
+        use_auth_token_kwargs = {"use_auth_token": self.use_auth_token} if self.use_auth_token else {}
+        
         with handle_name_conflicts():
             tokenizer = AutoTokenizer.from_pretrained(
                 self.tokenizer or self.name,
@@ -123,6 +126,7 @@ class Model:
                 use_fast=not self.slow_tokenizer,
                 tokenizer_type=self.tokenizer_type,
                 local_files_only=must_use_cache,
+                **use_auth_token_kwargs,
             )
 
         assert isinstance(tokenizer, PreTrainedTokenizerBase)


### PR DESCRIPTION
This PR adds ```use_auth_token``` to be able to access gated HuggingFace models such as LLaMa2 models.

HuggingFace PR for LLaMa2-7B Tuned Lens trained over [RedPajama-Data-1T-Sample](https://huggingface.co/datasets/togethercomputer/RedPajama-Data-1T-Sample): https://huggingface.co/spaces/AlignmentResearch/tuned-lens/discussions/41

