### PR TITLE
Moved data shuffling to just before tokenization step

### DIFF
--- a/tuned_lens/scripts/eval_loop.py
+++ b/tuned_lens/scripts/eval_loop.py
@@ -232,7 +232,7 @@ class Eval:
         # Note since we are not training we can just move the lens to the device.
         # No need to use DDP
         lenses = {name: lens.to(self.dist.device) for name, lens in lenses.items()}
-        dl = self.dist.data_loader(data)
+        dl = self.dist.dataloader(data)
         dl.seed(self.seed)
 
         for lens in lenses.values():

--- a/tuned_lens/scripts/ingredients.py
+++ b/tuned_lens/scripts/ingredients.py
@@ -60,6 +60,12 @@ class Data:
     max_length: int = 2048
     """The maximum length of the input sequences."""
 
+    dataset_shuffle: bool = False
+    """Whether to shuffle the dataset."""
+
+    dataset_shuffle_seed: int = 42
+    """Seed to use for shuffling the dataset"""
+
     def load(self, tokenizer: PreTrainedTokenizerBase) -> tuple[Dataset, float]:
         """Load the dataset, tokenize it and compute nats_to_bpb."""
         print(f"Loading dataset '{' '.join(self.name)}'")
@@ -73,6 +79,9 @@ class Data:
                 raise ValueError(
                     "Only Dataset and DatasetDict instances are supported."
                 )
+
+        if self.dataset_shuffle:
+            dataset = dataset.shuffle(self.dataset_shuffle_seed)
 
         processed, nats_to_bpb = chunk_and_tokenize(
             dataset,
@@ -351,7 +360,6 @@ class Distributed:
         else:
             rs = None
 
-        dp = dp.shuffle()
         dp = dp.sharding_filter()
         dp = dp.batch(self.per_gpu_batch_size)
         dp = dp.collate()

--- a/tuned_lens/scripts/train_loop.py
+++ b/tuned_lens/scripts/train_loop.py
@@ -324,7 +324,7 @@ class Train:
         assert model and tokenizer and data and lens and nats_to_bpb
 
         logger.debug(f"Creating data loader and setting seed to {self.seed} ...")
-        dl = self.dist.data_loader(data)
+        dl = self.dist.dataloader(data)
         dl.seed(self.seed)
         logger.debug("Creating optimizer and scheduler ...")
         params = [p for p in lens.parameters() if p.requires_grad]


### PR DESCRIPTION
This is particularly useful for datasets like `togethercomputer/RedPajama-Data-1T-Sample` that do not come preshuffled. Often the local shuffling done by the dataloader is insufficient for datasets this large.