### PR TITLE
Make lenses device agnostic using map_location in torch.load()

### DIFF
--- a/tuned_lens/nn/lenses.py
+++ b/tuned_lens/nn/lenses.py
@@ -276,7 +276,8 @@ class TunedLens(Lens):
             **{k: v for k, v in kwargs.items() if k not in load_artifact_varnames}
         }
         # Load parameters
-        state = th.load(ckpt_path, **th_load_kwargs)
+        device = unembed.unembedding.weight.device
+        state = th.load(ckpt_path, **th_load_kwargs, map_location=device)
 
         lens.layer_translators.load_state_dict(state)
 


### PR DESCRIPTION
Some .pt files on the huggingface space (for eg [this one](https://huggingface.co/spaces/AlignmentResearch/tuned-lens/tree/main/lens/EleutherAI/pythia-410m-deduped), looks like all pythia lenses might be affected? gpt2-large seems to work) contain "cuda:0". See the following screenshot (forgive me for opening a .pt file in vim, it won't happen again):

![image](https://github.com/user-attachments/assets/2efe56ba-e263-4edc-bc39-d804e740d84c)

This means that when th.load() gets called and the Unpickling occurs, it tries to load this onto "cuda:0" regardless of the torch backend on the machine, or the device the model itself is loaded on. This is a shame, as Mac users relying on MPS won't be able to load these lenses. 

The 2-line change in this commit checks what device the loaded embedding is on, and then loads the state (and as such the .pt file) onto this same device using map_location. I think this is quite an elegant solution that gives the user the flexibility to load their model onto the device of their choosing, and copy the lens onto the same device. Please let me know if another solution would be preferable, and do forgive me if I have gone against any conventions of contributing to OSS. This is my first pull request ever, I mean well!