### PR TITLE
feat: make wandb an optional dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,11 +19,13 @@ dependencies = [
     "huggingface_hub>=0.16.4",
     "simple-parsing>=0.1.4",
     "flatten-dict>=0.4.1",
-    "wandb>=0.15.0",
 ]
 version = "0.2.0"
 
 [project.optional-dependencies]
+training = [
+    "wandb>=0.15.0",
+]
 dev = [
     "pre-commit",
     "bump2version",

--- a/tuned_lens/scripts/train_loop.py
+++ b/tuned_lens/scripts/train_loop.py
@@ -163,7 +163,13 @@ class Train:
         if not self.dist.primary or not self.wandb:
             return None
 
-        from wandb.sdk.lib import runid
+        try:
+            from wandb.sdk.lib import runid
+        except ImportError:
+            raise ImportError(
+                "wandb is required for experiment tracking but is not installed. "
+                "Install it with: pip install tuned-lens[training]"
+            )
 
         return runid.generate_id()
 
@@ -173,7 +179,13 @@ class Train:
             return
 
         logger.debug("Initializing Weights & Biases ...")
-        import wandb
+        try:
+            import wandb
+        except ImportError:
+            raise ImportError(
+                "wandb is required for experiment tracking but is not installed. "
+                "Install it with: pip install tuned-lens[training]"
+            )
 
         wandb.init(
             config=dataclasses.asdict(self),
@@ -196,7 +208,13 @@ class Train:
         if not self.dist.primary or not self.wandb:
             return
 
-        import wandb
+        try:
+            import wandb
+        except ImportError:
+            raise ImportError(
+                "wandb is required for experiment tracking but is not installed. "
+                "Install it with: pip install tuned-lens[training]"
+            )
 
         log_dict = {}
         log_dict.update(


### PR DESCRIPTION
Move wandb from core dependencies to a `training` optional extra. Inference-only users no longer need wandb installed. The three import sites in train_loop.py now raise a clear error message pointing to `pip install tuned-lens[training]` when wandb is missing.