### PR TITLE
fix: plotly 6.x colorbar titleside compatibility

### DIFF
--- a/tuned_lens/plotting/trajectory_plotting.py
+++ b/tuned_lens/plotting/trajectory_plotting.py
@@ -178,8 +178,7 @@ class TrajectoryStatistic:
             y=self._layer_labels,
             z=self.stats if not log_scale else np.log10(self.stats),
             colorbar=dict(
-                title=f"{self.name} ({self.units})",
-                titleside="right",
+                title=dict(text=f"{self.name} ({self.units})", side="right"),
             ),
             colorscale=colorscale,
             zmax=max if not log_scale else np.log10(max),


### PR DESCRIPTION
## Summary

- Replace deprecated flat `titleside` colorbar property with nested `title=dict(text=..., side=...)` form
- Fixes compatibility with plotly 6.x where `titleside` was fully removed
- Backwards-compatible with plotly 5.x

Fixes #147