### PR TITLE
Add gpt-oss (GptOssForCausalLM) support to model_surgery

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,7 @@ def text_dataset(text_dataset_path: Path) -> Dataset:
         "facebook/opt-125m",
         "mockmodel/llama-tiny",
         "mockmodel/gemma-tiny",
+        "mockmodel/gpt-oss-tiny",
         "gpt2",
     ],
 )
@@ -52,6 +53,18 @@ def random_small_model(request: str) -> tr.PreTrainedModel:
             num_attention_heads=4,
             num_key_value_heads=4,
             head_dim=32,
+        )
+    elif small_model_name == "mockmodel/gpt-oss-tiny":
+        config = tr.GptOssConfig(
+            vocab_size=1_000,
+            hidden_size=128,
+            num_hidden_layers=4,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            head_dim=32,
+            intermediate_size=256,
+            num_local_experts=4,
+            num_experts_per_tok=2,
         )
     else:
         config = tr.AutoConfig.from_pretrained(small_model_name)

--- a/tuned_lens/model_surgery.py
+++ b/tuned_lens/model_surgery.py
@@ -15,6 +15,14 @@ import transformers as tr
 from torch import nn
 from transformers import models
 
+# GptOssForCausalLM was added in transformers 4.55; guard the import so that
+# older supported versions (pyproject pins transformers>=4.38.1) still import
+# this module. When unavailable, the isinstance branches below are simply skipped.
+try:
+    from transformers.models.gpt_oss.modeling_gpt_oss import GptOssModel as _GptOssModel
+except ImportError:  # transformers < 4.55
+    _GptOssModel = None
+
 
 def get_value_for_key(obj: Any, key: str) -> Any:
     """Get a value using `__getitem__` if `key` is numeric and `getattr` otherwise."""
@@ -123,6 +131,8 @@ def get_final_norm(model: Model) -> Norm:
         final_layer_norm = base_model.norm
     elif isinstance(base_model, models.gemma.modeling_gemma.GemmaModel):
         final_layer_norm = base_model.norm
+    elif _GptOssModel is not None and isinstance(base_model, _GptOssModel):
+        final_layer_norm = base_model.norm
     else:
         raise NotImplementedError(f"Unknown model type {type(base_model)}")
 
@@ -171,6 +181,8 @@ def get_transformer_layers(model: Model) -> tuple[str, th.nn.ModuleList]:
     elif isinstance(base_model, models.mistral.modeling_mistral.MistralModel):
         path_to_layers += ["layers"]
     elif isinstance(base_model, models.gemma.modeling_gemma.GemmaModel):
+        path_to_layers += ["layers"]
+    elif _GptOssModel is not None and isinstance(base_model, _GptOssModel):
         path_to_layers += ["layers"]
     else:
         raise NotImplementedError(f"Unknown model type {type(base_model)}")


### PR DESCRIPTION
get_final_norm and get_transformer_layers raised NotImplementedError for GptOssForCausalLM. Add branches mapping to base_model.norm and base_model.layers (same shape as Llama/Gemma). get_unembedding_matrix already works via get_output_embeddings().

The GptOssModel import is guarded (try/except) so transformers versions before 4.55, when gpt-oss was added, still import this module cleanly (pyproject pins transformers>=4.38.1); the branches are skipped when the symbol is unavailable.

Adds a mockmodel/gpt-oss-tiny fixture to random_small_model so the existing model_surgery tests cover it.